### PR TITLE
Fix badges localization

### DIFF
--- a/client/app/(profiles)/profile/[slug]/content.js
+++ b/client/app/(profiles)/profile/[slug]/content.js
@@ -14,9 +14,11 @@ import Graph from '@/app/(profiles)/profile/[slug]/components/sections/Graph';
 import useThemeStore from '@/stores/theme';
 import UserBanner from '@/app/components/ImageFromHash/UserBanner';
 import UserAvatar from '@/app/components/ImageFromHash/UserAvatar';
+import useLanguageStore, { t } from '@/stores/language';
 
 export default function Content({ profile }) {
   const theme = useThemeStore(state => state.theme);
+  const language = useLanguageStore(state => state.language);
 
   useEffect(() => {
     incrementViews(profile.slug);
@@ -79,13 +81,22 @@ export default function Content({ profile }) {
 
           {profile.badges.length > 0 && (
             <div className='flex items-center ml-4 gap-x-2'>
-              {profile.badges.map(badge => (
-                <Tooltip key={badge.name} content={badge.tooltip}>
+              {profile.badges.map(badgeId => (
+                <Tooltip
+                  content={t(`badges.${badgeId}`, {
+                    premiumSince: profile.subscriptionCreatedAt,
+                    lng: language,
+                    formatParams: {
+                      premiumSince: { year: 'numeric', month: 'long', day: 'numeric' }
+                    }
+                  })}
+                  key={badgeId}
+                >
                   <MotionImage 
-                    src={`/profile-badges/${theme === 'dark' ? 'white' : 'black'}_${badge.name.toLowerCase()}.svg`} 
+                    src={`/profile-badges/${theme === 'dark' ? 'white' : 'black'}_${badgeId}.svg`} 
                     width={24}
                     height={24}
-                    alt={`${badge.name} Badge`}
+                    alt={`${badgeId} Badge`}
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                   />

--- a/client/app/(profiles)/profile/u/[user_id]/content.js
+++ b/client/app/(profiles)/profile/u/[user_id]/content.js
@@ -200,11 +200,20 @@ export default function Content({ user }) {
             </h3>
 
             <div className='grid grid-cols-3 grid-rows-2 gap-y-2 gap-x-4'>
-              {(user.profile?.badges || []).map(badge => (
-                <Tooltip content={badge.tooltip} key={badge.name}>
+              {(user.profile?.badges || []).map(badgeId => (
+                <Tooltip
+                  content={t(`badges.${badgeId}`, {
+                    premiumSince: user.subscriptionCreatedAt,
+                    lng: language,
+                    formatParams: {
+                      premiumSince: { year: 'numeric', month: 'long', day: 'numeric' }
+                    }
+                  })}
+                  key={badgeId}
+                >
                   <Image
-                    src={`/profile-badges/${theme === 'dark' ? 'white' : 'black'}_${badge.name.toLowerCase()}.svg`}
-                    alt={`${badge.name} Badge`}
+                    src={`/profile-badges/${theme === 'dark' ? 'white' : 'black'}_${badgeId}.svg`}
+                    alt={`${badgeId} Badge`}
                     width={20}
                     height={20}
                   />
@@ -241,11 +250,20 @@ export default function Content({ user }) {
             </h3>
 
             <div className='grid grid-cols-3 grid-rows-2 gap-y-4 gap-x-6'>
-              {(user.profile?.badges || []).map(badge => (
-                <Tooltip content={badge.tooltip} key={badge.name}>
+              {(user.profile?.badges || []).map(badgeId => (
+                <Tooltip
+                  content={t(`badges.${badgeId}`, {
+                    premiumSince: user.subscriptionCreatedAt,
+                    lng: language,
+                    formatParams: {
+                      premiumSince: { year: 'numeric', month: 'long', day: 'numeric' }
+                    }
+                  })}
+                  key={badgeId}
+                >
                   <Image
-                    src={`/profile-badges/${theme === 'dark' ? 'white' : 'black'}_${badge.name.toLowerCase()}.svg`}
-                    alt={`${badge.name} Badge`}
+                    src={`/profile-badges/${theme === 'dark' ? 'white' : 'black'}_${badgeId}.svg`}
+                    alt={`${badgeId} Badge`}
                     width={20}
                     height={20}
                   />

--- a/client/app/(profiles)/profiles/components/Hero/Profiles/Card.jsx
+++ b/client/app/(profiles)/profiles/components/Hero/Profiles/Card.jsx
@@ -12,7 +12,7 @@ import Link from 'next/link';
 import { colord, extend } from 'colord';
 import mixPlugin from 'colord/plugins/mix';
 import a11yPlugin from 'colord/plugins/a11y';
-import { t } from '@/stores/language';
+import useLanguageStore, { t } from '@/stores/language';
 import UserBanner from '@/app/components/ImageFromHash/UserBanner';
 import UserAvatar from '@/app/components/ImageFromHash/UserAvatar';
 
@@ -22,6 +22,8 @@ extend([
 ]);
 
 export default function Card(props) {
+  const language = useLanguageStore(state => state.language);
+
   const formatter = new Intl.NumberFormat('en-US', {
     style: 'decimal',
     notation: 'compact',
@@ -143,10 +145,19 @@ export default function Card(props) {
                 {props.global_name}
               </h2>
 
-              {props.badges.map(({ name, tooltip }) => (
-                <Tooltip key={name} content={tooltip}>
+              {props.badges.map(badgeId => (
+                <Tooltip
+                  content={t(`badges.${badgeId}`, {
+                    premiumSince: props.subscriptionCreatedAt,
+                    lng: language,
+                    formatParams: {
+                      premiumSince: { year: 'numeric', month: 'long', day: 'numeric' }
+                    }
+                  })}
+                  key={badgeId}
+                >
                   <Image
-                    src={`/profile-badges/${(haveCustomColors || theme === 'dark') ? 'white' : 'black'}_${name.toLowerCase()}.svg`}
+                    src={`/profile-badges/${(haveCustomColors || theme === 'dark') ? 'white' : 'black'}_${badgeId}.svg`}
                     width={16}
                     height={16}
                     alt={`${name} Badge`}

--- a/client/locales/az.json
+++ b/client/locales/az.json
@@ -1242,7 +1242,7 @@
     "admin": "Admin",
     "moderator": "Moderator",
     "verified": "Doğrulanıb",
-    "premium": "Premium"
+    "premium": "{{premiumSince, datetime}} tarixindən bəri Premium"
   },
   "botPage": {
     "notVerifiedInfo": {

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -1242,7 +1242,7 @@
     "admin": "Admin",
     "moderator": "Moderator",
     "verified": "Verified",
-    "premium": "Premium"
+    "premium": "Premium since {{premiumSince, datetime}}"
   },
   "botPage": {
     "notVerifiedInfo": {

--- a/client/locales/tr.json
+++ b/client/locales/tr.json
@@ -1242,7 +1242,7 @@
     "admin": "Yönetici",
     "moderator": "Moderatör",
     "verified": "Onaylanmış",
-    "premium": "Premium"
+    "premium": "{{premiumSince, datetime}} tarihinden beri Premium"
   },
   "botPage": {
     "notVerifiedInfo": {

--- a/server/src/bot/commands/general/info.js
+++ b/server/src/bot/commands/general/info.js
@@ -164,7 +164,7 @@ module.exports = {
 
           var fetchedBadges = await getBadges(profile, userData?.subscription?.createdAt);
           var emptySlots = maxBadges - fetchedBadges.length;
-          var badges = fetchedBadges.map(badge => config.emojis.badges[badge.name.toLowerCase()] || emptySlotEmoji);
+          var badges = fetchedBadges.map(badge => config.emojis.badges[badge.id] || emptySlotEmoji);
         
           for (var i = 0; i < emptySlots; i++) badges.push(emptySlotEmoji);
 

--- a/server/src/routes/users/[id]/index.js
+++ b/server/src/routes/users/[id]/index.js
@@ -80,6 +80,7 @@ module.exports = {
         const profileBadges = profile ? getBadges(profile, userData?.subscription?.createdAt || null) : [];
         
         Object.assign(responseData, {
+          subscriptionCreatedAt: userData?.subscription?.createdAt || null,
           profile: {
             bio: profile.bio,
             badges: profileBadges,

--- a/server/src/utils/profiles/getBadges.js
+++ b/server/src/utils/profiles/getBadges.js
@@ -31,7 +31,7 @@ function getBadges(profile, premiumSince) {
     }
   ];
 
-  return badges.filter(badge => badge.condition()).map(badge => ({ name: badge.name, tooltip: badge.tooltip || badge.name }));
+  return badges.filter(badge => badge.condition()).map(badge => badge.id);
 }
 
 module.exports = getBadges;

--- a/server/src/utils/profiles/getBadges.js
+++ b/server/src/utils/profiles/getBadges.js
@@ -3,14 +3,14 @@ function getBadges(profile, premiumSince) {
 
   const badges = [
     {
-      name: 'Admin',
+      id: 'admin',
       condition: () => {
         const member = guild.members.cache.get(profile.user.id); 
         return member && member.roles.cache.has(config.roles.admin);
       }
     },
     {
-      name: 'Moderator',
+      id: 'moderator',
       condition: () => {
         const member = guild.members.cache.get(profile.user.id); 
         return member && (
@@ -21,12 +21,12 @@ function getBadges(profile, premiumSince) {
       }
     },
     {
-      name: 'Verified',
+      id: 'verified',
       condition: () => profile.verified
     },
     {
-      name: 'Premium',
-      tooltip: `Premium since ${new Date(premiumSince).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`,
+      id: 'premium',
+      // tooltip: `Premium since ${new Date(premiumSince).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`,
       condition: () => premiumSince
     }
   ];

--- a/server/src/utils/profiles/getBadges.js
+++ b/server/src/utils/profiles/getBadges.js
@@ -26,7 +26,6 @@ function getBadges(profile, premiumSince) {
     },
     {
       id: 'premium',
-      // tooltip: `Premium since ${new Date(premiumSince).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`,
       condition: () => premiumSince
     }
   ];


### PR DESCRIPTION
## Description
The tooltips for profile badges used to use the default language's tooltip text, even if the language was changed.

## Changes Made
[Refactor getBadges function to use badge IDs instead of names](https://github.com/discordplace/discord.place/commit/7d4d57de263814071a595600a6c5a75bc5c8c341)
[Use badge ids to get emojis in user info command](https://github.com/discordplace/discord.place/commit/c83cf7747d2d30bacea5ea2d61f12be29223d2ed)
[Refactor getBadges function to return badge IDs instead of objects](https://github.com/discordplace/discord.place/commit/b17804df66413ee03b6dba02c5b03a77d73a223f)
[Refactor getBadges function to remove unused comments](https://github.com/discordplace/discord.place/commit/0c38dfa31ce3c923bbd13e342634668ddf9f9eab)
[Update user profile response to include subscription creation date](https://github.com/discordplace/discord.place/commit/4b61b16740b6c95dd8277c96028a3d7e58a195da)
[Update localization files to use premium since date time](https://github.com/discordplace/discord.place/commit/afcc011d37de27db133cd91cd3ee30701e168dc6)
[Refactor Profile Card component to get tooltip contents from locale f…](https://github.com/discordplace/discord.place/commit/579377a93395ba8e98afb41861240de7e8136a0d)
[Refactor Profile Card component to get tooltip contents from locale f…](https://github.com/discordplace/discord.place/commit/3831e042654673001085584680192d8f4b0e2946)
[Refactor profile badge rendering to use badge IDs instead of names in…](https://github.com/discordplace/discord.place/commit/d332fbca709532497e385cce4731faa49849d723)

## Related Issues
N/A

## Screenshots (if applicable)
N/A

## Checklist
- [X] I have tested the changes locally.
- [X] I have reviewed my code for any potential issues.
- [X] I have checked for code style compliance.
- [X] I have added necessary labels and assigned reviewers.
- [X] I have squashed my commits into meaningful units.