### PR TITLE
Fix graphs displayed with zero data

### DIFF
--- a/client/app/(profiles)/profile/[slug]/content.js
+++ b/client/app/(profiles)/profile/[slug]/content.js
@@ -114,7 +114,7 @@ export default function Content({ profile }) {
           </div>
         </div>
 
-        <Graph profile={profile} />
+        {profile.dailyStats?.length > 0 && <Graph profile={profile} />}
 
         {profile.servers.length > 0 && <Servers profile={profile} />}
       </div>


### PR DESCRIPTION
## Description
The graphs on the profile page were visible even without data.

## Changes Made
[Refactor Profile Slug Content component to conditionally render the G…](https://github.com/discordplace/discord.place/commit/0005445aea555f083d15913b1429d3900a0eb6bb)

## Related Issues
N/A

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/c8a5e691-dcd9-461e-96c6-2cb4531c5de6)

## Checklist
- [X] I have tested the changes locally.
- [X] I have reviewed my code for any potential issues.
- [X] I have checked for code style compliance.
- [X] I have added necessary labels and assigned reviewers.
- [X] I have squashed my commits into meaningful units.