### PR TITLE
update english locale to follow en-US Int'l writing rules

### DIFF
--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -619,11 +619,11 @@
       "linkText": "our support server"
     },
     "themeDetails": {
-      "title": "About Theme",
+      "title": "About This Theme",
       "fields": {
-        "uploadedAt": "Uploaded At",
+        "uploadedAt": "Uploaded at",
         "categories": "Categories",
-        "publisher": "Publisher"
+        "publisher": "Published by"
       },
       "colors": {
         "copied": "Color {{color}} copied to clipboard.",


### PR DESCRIPTION
## Changes Made in This Commit 
1. en-US Int'l paradigm specification suggests that titles that include position specifiers should not be capitalized
2. Swapped `About Theme` to `About This Theme` to better follow the en-us Int'l paradigm specification for naming