### PR TITLE
Fix tab count display

### DIFF
--- a/client/app/(dashboard)/components/Table/index.jsx
+++ b/client/app/(dashboard)/components/Table/index.jsx
@@ -109,7 +109,7 @@ export default function Table({ tabs }) {
           >
             {tab.label}
 
-            <span className='flex items-center justify-center w-4 h-4 text-xs rounded-full bg-quaternary sm:bg-quaternary text-primary'>
+            <span className='flex items-center justify-center w-max px-1.5 h-4 text-xs rounded-full bg-quaternary sm:bg-quaternary text-primary'>
               {tab.count}
             </span>
 


### PR DESCRIPTION
This pull request includes a small change to the `Table` component in the `client/app/(dashboard)/components/Table/index.jsx` file. The change adjusts the styling of the span element that displays the tab count.

Styling adjustment:

* [`client/app/(dashboard)/components/Table/index.jsx`](diffhunk://#diff-27ea240cc4fb536fe8eaaf1930dc6ac385501579211971a3181ced9f71a962a5L112-R112): Changed the span element's class to use `w-max` and `px-1.5` for better styling and alignment of the tab count.