### PR TITLE
Remove unused getResponseTime function

### DIFF
--- a/server/src/client.js
+++ b/server/src/client.js
@@ -1,7 +1,6 @@
 // Modules
 const Discord = require('discord.js');
 const { CronJob } = require('cron');
-const axios = require('axios');
 const CloudflareAPI = require('cloudflare');
 const syncLemonSqueezyPlans = require('@/utils/payments/syncLemonSqueezyPlans');
 const updateMonthlyVotes = require('@/utils/updateMonthlyVotes');
@@ -334,20 +333,6 @@ module.exports = class Client {
     }).save();
 
     logger.info('Created new dashboard data.');
-  }
-
-  async getResponseTime() {
-    const baseUrl = config.backendUrl;
-
-    try {
-      await axios.post(`${baseUrl}/response-time`);
-
-      const response = await axios.get(`${baseUrl}/response-time`);
-
-      return response.data.responseTime;
-    } catch (error) {
-      logger.info(`Failed to get response time:\n${error}`);
-    }
   }
 
   async syncLemonSqueezyPlans() {


### PR DESCRIPTION
This pull request to `server/src/client.js` includes changes to remove the `axios` dependency and the `getResponseTime` method. These changes help to simplify the codebase by eliminating unused code and dependencies.

Codebase simplification:

* [`server/src/client.js`](diffhunk://#diff-f6861b176e4409c57d839b2b126db6b1a1cbec4962008a942a4fdb275ba35a45L4): Removed the `axios` dependency as it is no longer needed.
* [`server/src/client.js`](diffhunk://#diff-f6861b176e4409c57d839b2b126db6b1a1cbec4962008a942a4fdb275ba35a45L339-L352): Removed the `getResponseTime` method from the `Client` class, which included `axios` calls to fetch response time data.