### PR TITLE
fix(client/markdown): allow line breaks in rendered markdown content

### DIFF
--- a/client/app/components/Markdown/index.jsx
+++ b/client/app/components/Markdown/index.jsx
@@ -10,7 +10,7 @@ export default function Markdown({ children, className, rawEnabled }) {
   return (
     <div
       className={cn(
-        'markdown prose max-w-5xl min-w-[0px] dark:prose-invert',
+        'markdown break-words prose max-w-5xl min-w-[0px] dark:prose-invert',
         'prose-blockquote:border-l-primary prose-blockquote:text-tertiary',
         'prose-li:marker:text-tertiary',
         'prose-thead:border-b-[rgba(var(--bg-quaternary))] prose-tr:border-b-[rgba(var(--bg-tertiary))]',


### PR DESCRIPTION
This pull request includes a small but important change to the `Markdown` component in the `client/app/components/Markdown/index.jsx` file. The change ensures that long words within the markdown content will break correctly, improving the readability and layout of the rendered markdown.

* [`client/app/components/Markdown/index.jsx`](diffhunk://#diff-d0da64a23e30c0eeab1dc57a8cf112005290b02eb2be99239d4e51ba10781999L13-R13): Added the `break-words` class to the `Markdown` component to ensure long words break correctly.