### PR TITLE
fix(pagination): close input on blur and update page number

### DIFF
--- a/client/app/components/Pagination/index.jsx
+++ b/client/app/components/Pagination/index.jsx
@@ -125,6 +125,10 @@ export default function Pagination({ page, setPage, loading, total, limit, disab
                     setInputOpened(false);
                   }
                 }}
+                onBlur={() => {
+                  setInputOpened(false);
+                  setPage(Math.max(1, Math.min(totalPages, parseInt(inputValue))));
+                }}
                 maxLength={totalPages.toString().length}
               />
             ) : (


### PR DESCRIPTION
This pull request includes a small change to the `Pagination` component in `client/app/components/Pagination/index.jsx`. The change ensures that the page input field is properly handled when it loses focus (`onBlur` event).

* [`client/app/components/Pagination/index.jsx`](diffhunk://#diff-236d1d8fa246da7278789a2c79d724f1f46a9b228ed5f9f13f708861c7a9e7a8R128-R131): Added an `onBlur` event handler to close the input field and set the page number within valid bounds when the input field loses focus.