### PR TITLE
refactor(content): remove unnecessary nested divs from premium page

### DIFF
--- a/client/app/premium/content.jsx
+++ b/client/app/premium/content.jsx
@@ -218,12 +218,6 @@ export default function Page({ plans }) {
 
       <div className='absolute top-[-15%] h-[300px] w-full max-w-[800px] rounded-[5rem] bg-[#ffffff10] blur-[15rem]' />
 
-      <div>
-        <div>
-          asd
-        </div>
-      </div>
-
       <div className='flex w-full max-w-[800px] flex-col'>
         <motion.h1
           className={cn(


### PR DESCRIPTION
This pull request includes a small change to the `client/app/premium/content.jsx` file. The change involves removing unnecessary placeholder code.

* [`client/app/premium/content.jsx`](diffhunk://#diff-430ac1528d67e8e0d6d8e06f45a35e05fe27de5f00cdf16c1e4685c372f14282L221-L226): Removed a nested `div` containing placeholder text "asd" to clean up the component.