### PR TITLE
feat: redesign Tooltip usage in premium page

### DIFF
--- a/client/app/premium/content.jsx
+++ b/client/app/premium/content.jsx
@@ -18,7 +18,6 @@ import { IoCheckmarkCircle } from 'react-icons/io5';
 import FaQs from '@/app/premium/components/FaQs';
 import { LuShieldQuestion } from 'react-icons/lu';
 import Tooltip from '@/app/components/Tooltip';
-import { BiSolidInfoCircle } from 'react-icons/bi';
 import { t } from '@/stores/language';
 
 const BricolageGrotesque = Bricolage_Grotesque({ subsets: ['latin'], display: 'swap', adjustFontFallback: false });
@@ -325,23 +324,13 @@ export default function Page({ plans }) {
                 className='flex items-center justify-between p-4 first:rounded-t-xl last:rounded-b-xl odd:bg-secondary even:bg-tertiary'
                 key={index}
               >
-                <h2 className='flex w-full items-center gap-x-2 text-sm font-semibold text-tertiary'>
-                  {feature.label}
-
-                  {feature.info && (
-                    <Tooltip
-                      side='left'
-                      content={feature.info}
-                    >
-                      <div>
-                        <BiSolidInfoCircle
-                          className='text-tertiary'
-                          size={18}
-                        />
-                      </div>
-                    </Tooltip>
-                  )}
-                </h2>
+                <div className='flex w-full'>
+                  <Tooltip content={feature.info}>
+                    <h2 className='cursor-help text-sm font-semibold text-tertiary underline decoration-dotted underline-offset-4'>
+                      {feature.label}
+                    </h2>
+                  </Tooltip>
+                </div>
 
                 <div className='flex w-full justify-center text-sm font-medium'>
                   {feature.available_to.find(item => item.id === 'free').value}


### PR DESCRIPTION
This pull request to `client/app/premium/content.jsx` includes changes to improve the user interface by replacing an icon and restructuring the tooltip for feature information. The most important changes include replacing the `BiSolidInfoCircle` icon with a tooltip and restructuring the `h2` element to include the tooltip directly.

Improvements to the user interface:

* [`client/app/premium/content.jsx`](diffhunk://#diff-430ac1528d67e8e0d6d8e06f45a35e05fe27de5f00cdf16c1e4685c372f14282L21): Removed the import for `BiSolidInfoCircle`.
* [`client/app/premium/content.jsx`](diffhunk://#diff-430ac1528d67e8e0d6d8e06f45a35e05fe27de5f00cdf16c1e4685c372f14282L328-R333): Restructured the `h2` element to include the tooltip directly, improving the user experience by making the feature information more accessible.