### PR TITLE
fix: correct hash extraction logic in getHashFromURL function

### DIFF
--- a/client/lib/getHashFromURL.js
+++ b/client/lib/getHashFromURL.js
@@ -1,7 +1,7 @@
 function getHashFromURL(url, type) {
   const split = url.split(`/${type}/`);
 
-  return split[1].split('.')[0];
+  return split[1].split('/')[1].split('.')[0];
 }
 
 module.exports = getHashFromURL;


### PR DESCRIPTION
This pull request includes a small but important change to the `client/lib/getHashFromURL.js` file. The change modifies the `getHashFromURL` function to correctly parse the hash from the URL.

* [`client/lib/getHashFromURL.js`](diffhunk://#diff-f9634621efd0d9410262fb8674897b7177a699ef2ef58f3dffd75b8af89702dfL4-R4): Updated the `getHashFromURL` function to correctly handle URLs by splitting the string in a more precise manner.