### PR TITLE
fix: adjust max-width for reminder text in ActiveReminders component

### DIFF
--- a/client/app/(account)/account/components/Content/Tabs/ActiveReminders/index.jsx
+++ b/client/app/(account)/account/components/Content/Tabs/ActiveReminders/index.jsx
@@ -99,7 +99,7 @@ export default function ActiveReminders() {
                               {t('accountPage.tabs.activeReminders.fields.reminders.about')}
                             </div>
 
-                            <div className='max-w-[450px] break-words text-xs font-medium text-tertiary'>
+                            <div className='max-w-[60w] break-words text-xs font-medium text-tertiary xl:max-w-[450px]'>
                               {reminder.about}
                             </div>
 


### PR DESCRIPTION
This pull request includes a small but important change to the `ActiveReminders` component in the `client/app/(account)/account/components/Content/Tabs/ActiveReminders/index.jsx` file. The change adjusts the maximum width of the reminder text to improve the layout and readability on different screen sizes.

* [`client/app/(account)/account/components/Content/Tabs/ActiveReminders/index.jsx`](diffhunk://#diff-7b71f7055ebcedfc2bdaeab56a80d0bf55d915ae045ff4bcdb6839fb7686c678L102-R102): Modified the `max-w` class to use a percentage-based width with an additional `xl:max-w` class for larger screens.