### PR TITLE
fix: use avatar_url instead of avatar in user profile page

### DIFF
--- a/client/app/(profiles)/profile/u/[user_id]/content.js
+++ b/client/app/(profiles)/profile/u/[user_id]/content.js
@@ -127,10 +127,10 @@ export default function Content({ user }) {
         )}
 
         <div className='pointer-events-none relative bottom-16 left-8 -mb-12 flex w-full items-center sm:mb-[-7.5rem]'>
-          {user.avatar ? (
+          {user.avatar_url ? (
             <UserAvatar
               id={user.id}
-              hash={user.avatar}
+              hash={getHashFromURL(user.avatar_url)}
               size={128}
               width={128}
               height={128}


### PR DESCRIPTION
This pull request includes a small change to the `client/app/(profiles)/profile/u/[user_id]/content.js` file. The change updates the code to use `user.avatar_url` instead of `user.avatar` and modifies the `hash` property to use a function `getHashFromURL`.

* `client/app/(profiles)/profile/u/[user_id]/content.js`: Updated to use `user.avatar_url` instead of `user.avatar` and modified the `hash` property to use the `getHashFromURL` function. ([client/app/(profiles)/profile/u/[user_id]/content.jsL130-R133](diffhunk://#diff-f3d760974473eb7f692ee3dc4c95b030c9248bbcbe6f20b9baa4286d9ea2c8d3L130-R133))