### PR TITLE
refactor: remove loading='lazy' attribute from multiple image components

### DIFF
--- a/client/app/(blogs)/blogs/[id]/components/Header.jsx
+++ b/client/app/(blogs)/blogs/[id]/components/Header.jsx
@@ -39,7 +39,6 @@ export default function Header({ data }) {
         width={512}
         height={512}
         className='size-full max-h-[440px] rounded-lg bg-tertiary object-cover'
-        loading='lazy'
       />
     </>
   );

--- a/client/app/(bots)/bots/[id]/components/Tabs/Reviews.jsx
+++ b/client/app/(bots)/bots/[id]/components/Tabs/Reviews.jsx
@@ -148,7 +148,6 @@ export default function Reviews({ bot }) {
                     width={48}
                     height={48}
                     className='size-[48px] rounded-2xl'
-                    loading='lazy'
                   />
                 ) : (
                   <Image
@@ -157,7 +156,6 @@ export default function Reviews({ bot }) {
                     width={48}
                     height={48}
                     className='size-[48px] rounded-2xl'
-                    loading='lazy'
                   />
                 )}
 

--- a/client/app/(bots)/bots/[id]/manage/components/ExtraOwners/index.jsx
+++ b/client/app/(bots)/bots/[id]/manage/components/ExtraOwners/index.jsx
@@ -176,7 +176,6 @@ export default function ExtraOwners({ botId, canEditExtraOwners }) {
                   width={32}
                   height={32}
                   className='rounded-full'
-                  loading='lazy'
                 />
 
                 <span className='font-medium text-secondary'>

--- a/client/app/(dashboard)/components/Table/ColumnRenderer.jsx
+++ b/client/app/(dashboard)/components/Table/ColumnRenderer.jsx
@@ -72,7 +72,6 @@ export default function ColumnRenderer({ data }) {
             height={32}
             alt={`Emoji ${data.id}`}
             className='pointer-events-none size-[32px] object-contain'
-            loading='lazy'
           />
 
           <span className='font-medium'>
@@ -92,7 +91,6 @@ export default function ColumnRenderer({ data }) {
                 width={32}
                 height={32}
                 className='pointer-events-none size-[32px] object-contain'
-                loading='lazy'
               />
             ))}
           </div>

--- a/client/app/(emojis)/emojis/components/Hero/EmojiCard/Package.jsx
+++ b/client/app/(emojis)/emojis/components/Hero/EmojiCard/Package.jsx
@@ -36,7 +36,6 @@ export default function EmojiPackageCard({ overridedImages, id, name, categories
                 className='size-full max-h-[48px] max-w-[48px] rounded-xl bg-secondary object-contain transition-all ease-in-out group-hover:bg-tertiary'
                 width={64}
                 height={64}
-                loading='lazy'
               />
             ))}
 

--- a/client/app/(emojis)/emojis/components/PackagePreview/index.jsx
+++ b/client/app/(emojis)/emojis/components/PackagePreview/index.jsx
@@ -215,7 +215,6 @@ export default function PackagePreview({ image_urls, setImageURLs, setIsPackage,
               height={64}
               alt={''}
               className='size-[46px] object-contain sm:size-[64px]'
-              loading='lazy'
             />
           </motion.div>
         ))}

--- a/client/app/(home)/components/InfoCards/Mock/ReviewCard.jsx
+++ b/client/app/(home)/components/InfoCards/Mock/ReviewCard.jsx
@@ -12,7 +12,6 @@ export default function MockReviewCard({ username, content, rating }) {
           width={32}
           height={32}
           className='size-[24px] rounded-full mobile:size-[32px]'
-          loading='lazy'
         />
 
         <h3 className='truncate text-sm font-medium mobile:text-base'>

--- a/client/app/(profiles)/profile/[slug]/components/sections/Social.jsx
+++ b/client/app/(profiles)/profile/[slug]/components/sections/Social.jsx
@@ -80,7 +80,6 @@ export default function Social({ data }) {
                     width={20}
                     height={20}
                     alt={`${social.type} Icon`}
-                    loading='lazy'
                   />
 
                   <span className='w-full truncate'>

--- a/client/app/(profiles)/profile/[slug]/edit/components/Socials.jsx
+++ b/client/app/(profiles)/profile/[slug]/edit/components/Socials.jsx
@@ -189,7 +189,6 @@ export default function Socials({ profile }) {
                     width={20}
                     height={20}
                     alt={`${social.type} Icon`}
-                    loading='lazy'
                   />
 
                   <span className='w-full truncate'>
@@ -237,7 +236,6 @@ export default function Socials({ profile }) {
                 width={20}
                 height={20}
                 alt={`${newSocialType} Icon`}
-                loading='lazy'
               />
             )}
 

--- a/client/app/(servers)/servers/[id]/components/Tabs/Reviews.jsx
+++ b/client/app/(servers)/servers/[id]/components/Tabs/Reviews.jsx
@@ -148,7 +148,6 @@ export default function Reviews({ server }) {
                     width={48}
                     height={48}
                     className='size-[48px] rounded-2xl'
-                    loading='lazy'
                   />
                 ) : (
                   <Image
@@ -157,7 +156,6 @@ export default function Reviews({ server }) {
                     width={48}
                     height={48}
                     className='size-[48px] rounded-2xl'
-                    loading='lazy'
                   />
                 )}
 

--- a/client/app/components/Footer/index.jsx
+++ b/client/app/components/Footer/index.jsx
@@ -162,7 +162,6 @@ export default function Footer() {
           height={200}
           className='size-[48px]'
           alt='discord.place Logo'
-          loading='lazy'
         />
 
         <h2 className='max-w-[350px] text-2xl font-bold text-primary'>
@@ -232,7 +231,6 @@ export default function Footer() {
               width={100}
               height={25}
               alt='nodesty.com Logo'
-              loading='lazy'
             />
           </Link>
         </div>

--- a/client/app/components/Header/CollapsedHeader.jsx
+++ b/client/app/components/Header/CollapsedHeader.jsx
@@ -49,7 +49,6 @@ export default function CollapsedHeader({ pathname }) {
             height={64}
             className='size-[48px]'
             alt='discord.place Logo'
-            loading='lazy'
           />
         </Link>
       </div>

--- a/client/app/components/Logo/WithText.jsx
+++ b/client/app/components/Logo/WithText.jsx
@@ -25,7 +25,6 @@ export default function WithText({ className }) {
         height={64}
         alt='discord.place Logo'
         className='size-[32px]'
-        loading='lazy'
       />
 
       <div


### PR DESCRIPTION
This pull request removes the `loading='lazy'` attribute from various image components across multiple files to ensure images load immediately rather than lazily.