### PR TITLE
fix(ImageFromHash): show default avatar while current source loading

### DIFF
--- a/client/app/components/ImageFromHash/UserAvatar.jsx
+++ b/client/app/components/ImageFromHash/UserAvatar.jsx
@@ -9,7 +9,7 @@ import { useLocalStorage } from 'react-use';
 export default function UserAvatar({ id, hash, format, size, className, motionOptions, ...props }) {
   const defaultAvatarURL = '/default-discord-avatar.png';
 
-  const [currentSource, setCurrentSource] = useState(defaultAvatarURL);
+  const [currentSource, setCurrentSource] = useState(null);
   const [isErrorOccurred, setIsErrorOccurred] = useState(false);
   const [hashesRefreshed, setHashesRefreshed] = useLocalStorage('hashesRefreshed', []);
 
@@ -81,7 +81,7 @@ export default function UserAvatar({ id, hash, format, size, className, motionOp
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, hash]);
 
-  if (!hash) return (
+  if (!hash || !currentSource) return (
     <MotionImage
       key={`user-avatar-${id}-replaced-with-default-avatar`}
       src={defaultAvatarURL}

--- a/client/app/components/ImageFromHash/UserBanner.jsx
+++ b/client/app/components/ImageFromHash/UserBanner.jsx
@@ -9,7 +9,7 @@ import { useLocalStorage } from 'react-use';
 export default function UserBanner({ id, hash, format, size, className, motionOptions, ...props }) {
   const defaultBannerURL = '/default-discord-banner.png';
 
-  const [currentSource, setCurrentSource] = useState(defaultBannerURL);
+  const [currentSource, setCurrentSource] = useState(null);
   const [isErrorOccurred, setIsErrorOccurred] = useState(false);
   const [hashesRefreshed, setHashesRefreshed] = useLocalStorage('hashesRefreshed', []);
 
@@ -81,7 +81,7 @@ export default function UserBanner({ id, hash, format, size, className, motionOp
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, hash]);
 
-  if (!hash) return (
+  if (!hash || !currentSource) return (
     <MotionImage
       key={`user-banner-${id}-replaced-with-default-banner`}
       src={defaultBannerURL}


### PR DESCRIPTION
This pull request includes changes to the `UserAvatar` and `UserBanner` components to improve the handling of default images. The modifications ensure that the components only display the default image when necessary.

Changes to `UserAvatar` component:

* [`client/app/components/ImageFromHash/UserAvatar.jsx`](diffhunk://#diff-a680c69ab51e6a6ac6cf9a8bfb77b3cf8befee1fe2ca3947823feb829cbaee18L12-R12): Updated the initial state of `currentSource` from `defaultAvatarURL` to `null` and modified the conditional rendering to check for both `hash` and `currentSource`. [[1]](diffhunk://#diff-a680c69ab51e6a6ac6cf9a8bfb77b3cf8befee1fe2ca3947823feb829cbaee18L12-R12) [[2]](diffhunk://#diff-a680c69ab51e6a6ac6cf9a8bfb77b3cf8befee1fe2ca3947823feb829cbaee18L84-R84)

Changes to `UserBanner` component:

* [`client/app/components/ImageFromHash/UserBanner.jsx`](diffhunk://#diff-db6b129cfcc179798036d7f7a51b62a9cc4331b7c4bd29802cc8cfaf02f861d4L12-R12): Updated the initial state of `currentSource` from `defaultBannerURL` to `null` and modified the conditional rendering to check for both `hash` and `currentSource`. [[1]](diffhunk://#diff-db6b129cfcc179798036d7f7a51b62a9cc4331b7c4bd29802cc8cfaf02f861d4L12-R12) [[2]](diffhunk://#diff-db6b129cfcc179798036d7f7a51b62a9cc4331b7c4bd29802cc8cfaf02f861d4L84-R84)