### PR TITLE
fix(UserPage): update avatar URL property to use camelCase

### DIFF
--- a/client/app/(profiles)/profile/u/[user_id]/content.js
+++ b/client/app/(profiles)/profile/u/[user_id]/content.js
@@ -127,10 +127,10 @@ export default function Content({ user }) {
         )}
 
         <div className='pointer-events-none relative bottom-16 left-8 -mb-12 flex w-full items-center sm:mb-[-7.5rem]'>
-          {user.avatar_url ? (
+          {user.avatarURL ? (
             <UserAvatar
               id={user.id}
-              hash={getHashFromURL(user.avatar_url)}
+              hash={getHashFromURL(user.avatarURL)}
               size={128}
               width={128}
               height={128}


### PR DESCRIPTION
This pull request includes a small change to the `client/app/(profiles)/profile/u/[user_id]/content.js` file. The change updates the property name for the user's avatar URL to use camelCase.

* `client/app/(profiles)/profile/u/[user_id]/content.js`: Changed `user.avatar_url` to `user.avatarURL` to follow camelCase naming convention. ([client/app/(profiles)/profile/u/[user_id]/content.jsL130-R133](diffhunk://#diff-f3d760974473eb7f692ee3dc4c95b030c9248bbcbe6f20b9baa4286d9ea2c8d3L130-R133))