### PR TITLE
fix(UserProfile): add missing parameters to getHashFromURL function calls

### DIFF
--- a/client/app/(profiles)/profile/u/[user_id]/content.js
+++ b/client/app/(profiles)/profile/u/[user_id]/content.js
@@ -107,7 +107,7 @@ export default function Content({ user }) {
           <div className='relative'>
             <UserBanner
               id={user.id}
-              hash={getHashFromURL(user.bannerURL)}
+              hash={getHashFromURL(user.bannerURL, 'banners')}
               alt={`${user.username}'s banner`}
               size={1024}
               width={1024}
@@ -130,7 +130,7 @@ export default function Content({ user }) {
           {user.avatarURL ? (
             <UserAvatar
               id={user.id}
-              hash={getHashFromURL(user.avatarURL)}
+              hash={getHashFromURL(user.avatarURL, 'avatars')}
               size={128}
               width={128}
               height={128}


### PR DESCRIPTION
This pull request includes changes to improve the handling of user banner and avatar URLs by specifying the type of asset in the `getHashFromURL` function.

Improvements to URL handling:

* `client/app/(profiles)/profile/u/[user_id]/content.js`: Modified the `getHashFromURL` function calls to include the asset type ('banners' for banner URLs and 'avatars' for avatar URLs) for better URL management. ([client/app/(profiles)/profile/u/[user_id]/content.jsL110-R110](diffhunk://#diff-f3d760974473eb7f692ee3dc4c95b030c9248bbcbe6f20b9baa4286d9ea2c8d3L110-R110), [client/app/(profiles)/profile/u/[user_id]/content.jsL133-R133](diffhunk://#diff-f3d760974473eb7f692ee3dc4c95b030c9248bbcbe6f20b9baa4286d9ea2c8d3L133-R133))