### PR TITLE
fix(Authentication): log error when token verification fails

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -122,6 +122,7 @@ module.exports = class Server {
 
           next();
         } catch (error) {
+          logger.error('There was an error verifying the token:', error);
           response.clearCookie('token');
 
           return response.sendError('Unauthorized', 401);


### PR DESCRIPTION
This pull request includes a small change to the `server/src/server.js` file. The change adds an error logging statement when there is an error verifying the token, improving the debugging process.

* [`server/src/server.js`](diffhunk://#diff-1ce490ef081c1064c1bcc2dfdd71617a390b3b9624b48a0e3935b23e6698edfbR125): Added an error logging statement in the token verification error handling block.