### PR TITLE
fix: correct user ID for most voted user in database, add is_most_vot…

### DIFF
--- a/server/src/schemas/MonthlyVotes.js
+++ b/server/src/schemas/MonthlyVotes.js
@@ -12,10 +12,14 @@ const MonthlyVotesSchema = new Schema({
         type: Date,
         default: Date.now
       },
-      most_voted: {
+      most_voted_user: {
         type: String,
         default: null,
         required: false
+      },
+      is_most_voted: {
+        type: Boolean,
+        default: false
       }
     }
   ]
@@ -23,21 +27,29 @@ const MonthlyVotesSchema = new Schema({
   timestamps: true
 });
 
-MonthlyVotesSchema.statics.updateMonthlyVotes = async function (identifier, votes, Model) {
+MonthlyVotesSchema.statics.updateMonthlyVotes = async function (identifier, data, Model) {
   const month = new Date().getMonth() + 1;
   const year = new Date().getFullYear();
 
-  const mostVoted = await Model.findOne({ id: identifier }).sort({ votes: -1 }).limit(1);
+  const mostVotedUser = data.voters.sort((a, b) => b.vote - a.vote)[0];
+
   const query = { identifier };
-  const updateData = { month, year, votes, created_at: new Date(), most_voted: mostVoted ? mostVoted.id : null };
+  const updateData = {
+    month,
+    year,
+    votes: data.votes,
+    created_at: new Date(),
+    most_voted_user: mostVotedUser ? mostVotedUser.user.id : null,
+    is_most_voted: data.isMostVoted
+  };
 
   // Try to update the existing document
   const result = await this.updateOne(
     { identifier, 'data.month': month, 'data.year': year },
     {
       $set: {
-        'data.$.votes': votes,
-        'data.$.most_voted': mostVoted ? mostVoted.id : null
+        'data.$.votes': data.votes,
+        'data.$.most_voted_user': mostVotedUser ? mostVotedUser.user.id : null
       }
     }
   );

--- a/server/src/utils/updateMonthlyVotes.js
+++ b/server/src/utils/updateMonthlyVotes.js
@@ -3,14 +3,34 @@ const Server = require('@/schemas/Server');
 const Bot = require('@/schemas/Bot');
 
 async function updateMonthlyVotes() {
-  const servers = await Server.find();
+  const servers = await Server.find().sort({ votes: -1 });
+  const mostVotedServer = servers[0];
+
   for (const server of servers) {
-    await ServerMonthlyVotes.updateMonthlyVotes(server.id, server.votes, Server);
+    await ServerMonthlyVotes.updateMonthlyVotes(
+      server.id,
+      {
+        votes: server.votes,
+        voters: server.voters,
+        isMostVoted: mostVotedServer && mostVotedServer.id === server.id
+      },
+      Server
+    );
   }
 
-  const bots = await Bot.find();
+  const bots = await Bot.find().sort({ votes: -1 });
+  const mostVotedBot = bots[0];
+
   for (const bot of bots) {
-    await BotMonthlyVotes.updateMonthlyVotes(bot.id, bot.votes, Bot);
+    await BotMonthlyVotes.updateMonthlyVotes(
+      bot.id,
+      {
+        votes: bot.votes,
+        voters: bot.voters,
+        isMostVoted: mostVotedBot && mostVotedBot.id === bot.id
+      },
+      Bot
+    );
   }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `MonthlyVotes` schema and the `updateMonthlyVotes` utility function to improve the handling of monthly vote data and to track the most voted user or bot.

Schema updates:

* Renamed the `most_voted` field to `most_voted_user` and added a new boolean field `is_most_voted` in the `MonthlyVotesSchema`.
* Updated the `updateMonthlyVotes` static method to handle the new `most_voted_user` and `is_most_voted` fields, and to use the `data` parameter instead of `votes`.

Utility function updates:

* Modified the `updateMonthlyVotes` function in `server/src/utils/updateMonthlyVotes.js` to sort servers and bots by votes before processing.
* Added logic to determine the most voted server and bot, and passed this information to the `updateMonthlyVotes` method.