### PR TITLE
fix(commands/ping): refactor to use getServerResponseTime utility

### DIFF
--- a/server/src/bot/commands/general/ping.js
+++ b/server/src/bot/commands/general/ping.js
@@ -1,7 +1,7 @@
-const axios = require('axios');
 const mongoose = require('mongoose');
 const ansiColors = require('ansi-colors');
 const getLocalizedCommand = require('@/utils/localization/getLocalizedCommand');
+const getServerResponseTime = require('@/utils/getServerResponseTime');
 
 module.exports = {
   data: {
@@ -14,10 +14,7 @@ module.exports = {
     if (!interaction.deferred && !interaction.replied) await interaction.deferReply();
 
     const websocketHeartbeat = interaction.client.ws.ping;
-    let serverResponseTime = 'N/A';
-
-    const response = await axios.get(`${config.backendUrl}/response-time`, { timeout: 1000 }).catch(() => null);
-    if (response?.data?.responseTime) serverResponseTime = `${response.data.responseTime}ms`;
+    const serverResponseTime = await getServerResponseTime();
 
     let mongoosePing = 'N/A';
 

--- a/server/src/utils/getServerResponseTime.js
+++ b/server/src/utils/getServerResponseTime.js
@@ -1,0 +1,17 @@
+const axios = require('axios');
+
+async function getServerResponseTime() {
+  const url = `${config.backendUrl}/response-time`;
+
+  try {
+    await axios.post(url, { timeout: 1000 }).catch(() => null);
+
+    const response = await axios.get(url, { timeout: 1000 }).catch(() => null);
+
+    return response?.data?.responseTime || 'N/A';
+  } catch (error) {
+    return 'N/A';
+  }
+}
+
+module.exports = getServerResponseTime;


### PR DESCRIPTION
This pull request includes changes to the `ping` command to improve the way server response time is fetched by refactoring the code into a separate utility function.
* [`server/src/bot/commands/general/ping.js`](diffhunk://#diff-728556c0fd76f5c24e8a01cbeb110b953b7bea59a3774bb87f75d7be5308dc6bL1-R4): Removed the `axios` import and added an import for the new `getServerResponseTime` utility function.
* [`server/src/bot/commands/general/ping.js`](diffhunk://#diff-728556c0fd76f5c24e8a01cbeb110b953b7bea59a3774bb87f75d7be5308dc6bL17-R17): Modified the `ping` command to use the `getServerResponseTime` utility function instead of directly making the `axios` request.
* [`server/src/utils/getServerResponseTime.js`](diffhunk://#diff-1820e41d2b12f52f738597f81b2dabc9443ee69c9c823cb3de7fa5447747d83dR1-R17): Added a new utility function `getServerResponseTime` that handles fetching the server response time.